### PR TITLE
Enable only Fortran in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(HarmonieDaTools)
+project(HarmonieDaTools LANGUAGES Fortran)
 
-enable_language(Fortran)
 find_package (Python3 COMPONENTS Interpreter)
 
 enable_testing()


### PR DESCRIPTION
Now CMakeLists.txt enables support not only for Fortran (via `enable_language`) but also for C and CXX since the last two are the default option if no language is selected in `program`. Because the only language of the project is Fortran we don't really need the other two, and even more, now the CMake configure step would fail if there's no CXX compiler installed, even though it isn't needed for building the source code. This PR updates the CMakeLists.txt to enable only the Fortran language.